### PR TITLE
ether: Switch to the unified LED capabilities overlay

### DIFF
--- a/overlay/vendor/cmsdk/cm/res/res/values/config.xml
+++ b/overlay/vendor/cmsdk/cm/res/res/values/config.xml
@@ -18,7 +18,19 @@
     <bool name="config_proximityCheckOnWake">true</bool>
     <bool name="config_proximityCheckOnWakeEnabledByDefault">false</bool>
 
-    <bool name="config_useSegmentedBatteryLed">true</bool>
-    <bool name="config_adjustableNotificationLedBrightness">true</bool>
+    <!-- All the capabilities of the LEDs on this device, stored as a bit field.
+         This integer should equal the sum of the corresponding value for each
+         of the following capabilities present:
+
+         LIGHTS_RGB_NOTIFICATION_LED = 1
+         LIGHTS_RGB_BATTERY_LED = 2
+         LIGHTS_MULTIPLE_NOTIFICATION_LED = 4
+         LIGHTS_PULSATING_LED = 8
+         LIGHTS_SEGMENTED_BATTERY_LED = 16
+         LIGHTS_ADJUSTABLE_NOTIFICATION_LED_BRIGHTNESS = 32
+
+         For example, a device support pulsating, RGB notification and
+         battery LEDs would set this config to 11. -->
+    <integer name="config_deviceLightCapabilities" translatable="false">48</integer>
 
 </resources>


### PR DESCRIPTION
* The old overlays have now been removed in favor
  of a single unified and extensible overlay.

Change-Id: I3c1ec399a19e9dd3ad97e74993133cec9ffb5fb8
Signed-off-by: Paul Keith <javelinanddart@gmail.com>